### PR TITLE
Enable TLS for redis

### DIFF
--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           workspace=$(pwd)
           sed -i 's/__GNU_VISIBLE/1/' /d/a/_temp/msys64/usr/include/dlfcn.h
-          cd redis-${{ env.RELEASE_VERSION }} && make -i PREFIX=$workspace/dist install
+          cd redis-${{ env.RELEASE_VERSION }} && make -i PREFIX=$workspace/dist install BUILD_TLS=yes
           cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll redis.conf sentinel.conf $workspace/dist/bin/
           cd $workspace/dist/
           mv bin Redis-${{ env.RELEASE_VERSION }}-Windows-x64

--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -1,8 +1,8 @@
 name: Cron Build Redis
 
-#on:
-#  schedule:
-#    - cron:  '0 1 * * *'
+on:
+  schedule:
+    - cron:  '0 1 * * *'
 
 jobs:
   build:
@@ -43,14 +43,14 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: gcc make pkg-config mingw-w64-x86_64-python
+          install: gcc make pkg-config mingw-w64-x86_64-python libopenssl openssl-devel
       - name: Build Redis
         if: ${{ success() }}
         run: |
           workspace=$(pwd)
           sed -i 's/__GNU_VISIBLE/1/' /d/a/_temp/msys64/usr/include/dlfcn.h
           cd redis-${{ env.RELEASE_VERSION }} && make -i PREFIX=$workspace/dist install BUILD_TLS=yes
-          cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll redis.conf sentinel.conf $workspace/dist/bin/
+          cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll /d/a/_temp/msys64/usr/bin/msys-crypto-3.dll /d/a/_temp/msys64/usr/bin/msys-ssl-3.dll redis.conf sentinel.conf $workspace/dist/bin/
           cd $workspace/dist/
           mv bin Redis-${{ env.RELEASE_VERSION }}-Windows-x64
           tar -cvzf $workspace/Redis-${{ env.RELEASE_VERSION }}-Windows-x64.tar.gz Redis-${{ env.RELEASE_VERSION }}-Windows-x64/*

--- a/.github/workflows/ci-cron.yml
+++ b/.github/workflows/ci-cron.yml
@@ -1,8 +1,8 @@
 name: Cron Build Redis
 
-on:
-  schedule:
-    - cron:  '0 1 * * *'
+#on:
+#  schedule:
+#    - cron:  '0 1 * * *'
 
 jobs:
   build:

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: gcc make pkg-config mingw-w64-x86_64-python libopenssl
+          install: gcc make pkg-config mingw-w64-x86_64-python libopenssl openssl-devel
       - name: Build Redis
         if: ${{ success() }}
         run: |

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -47,7 +47,7 @@ jobs:
           workspace=$(pwd)
           sed -i 's/__GNU_VISIBLE/1/' /d/a/_temp/msys64/usr/include/dlfcn.h
           cd redis-${{ inputs.tag_name }} && make -i PREFIX=$workspace/dist install BUILD_TLS=yes
-          cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll redis.conf sentinel.conf $workspace/dist/bin/
+          cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll /d/a/_temp/msys64/usr/bin/msys-crypto-3.dll /d/a/_temp/msys64/usr/bin/msys-ssl-3.dll redis.conf sentinel.conf $workspace/dist/bin/
           cd $workspace/dist/
           mv bin Redis-${{ inputs.tag_name }}-Windows-x64
           tar -cvzf $workspace/Redis-${{ inputs.tag_name }}-Windows-x64.tar.gz Redis-${{ inputs.tag_name }}-Windows-x64/*

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: gcc make pkg-config mingw-w64-x86_64-python
+          install: gcc make pkg-config mingw-w64-x86_64-python libssl-dev
       - name: Build Redis
         if: ${{ success() }}
         run: |

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           workspace=$(pwd)
           sed -i 's/__GNU_VISIBLE/1/' /d/a/_temp/msys64/usr/include/dlfcn.h
-          cd redis-${{ inputs.tag_name }} && make -i PREFIX=$workspace/dist install
+          cd redis-${{ inputs.tag_name }} && make -i PREFIX=$workspace/dist install BUILD_TLS=yes
           cp $workspace/README.md $workspace/start.bat /d/a/_temp/msys64/usr/bin/msys-2.0.dll redis.conf sentinel.conf $workspace/dist/bin/
           cd $workspace/dist/
           mv bin Redis-${{ inputs.tag_name }}-Windows-x64

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: gcc make pkg-config mingw-w64-x86_64-python openssl-devel
+          install: gcc make pkg-config mingw-w64-x86_64-python libopenssl
       - name: Build Redis
         if: ${{ success() }}
         run: |

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -6,7 +6,7 @@ on:
       tag_name:
         description: 'version to build'
         required: true
-        default: "7.0.8"
+        default: "6.2.13"
         type: string
       latest:
         description: 'Indicator of whether or not is a prerelease'

--- a/.github/workflows/ci-diy.yml
+++ b/.github/workflows/ci-diy.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          install: gcc make pkg-config mingw-w64-x86_64-python libssl-dev
+          install: gcc make pkg-config mingw-w64-x86_64-python openssl-devel
       - name: Build Redis
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
Redis has the ability to support TLS natively. This needs to be added at build time with extra flags.
To run redis and connect via TLS, two msys dll are required in the final archive.

To use TLS, the redis.conf file needs the TLS section to be filled in with certificate and ca information.