### PR TITLE
pref: 优化关闭指令避免pid文件残留

### DIFF
--- a/RedisService.csproj
+++ b/RedisService.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
修复 Windows 服务停止 Redis 时因直接调用 `Process.Kill()` 导致 pid 文件无法清理的问题

本次修改调整为：

1. 优先使用 `redis-cli SHUTDOWN` 进行优雅关闭
2. 等待进程正常退出
3. 若超时则再使用 `Kill()` 作为兜底

这样可确保 Redis 正常执行关停流程、自动删除 pid 文件，同时保持与原有行为兼容。

------------------------------------------------------------------------------------------------------------------

Fixed an issue where the PID file was not cleaned up when directly calling `Process.Kill()` to stop Redis on Windows.

This update adjusts the process as follows:

1. Prioritize graceful shutdown using `redis-cli SHUTDOWN`.

2. Wait for the process to exit normally.

3. If a timeout occurs, use `Kill()` as a fallback.

This ensures that Redis executes the shutdown process normally, automatically deletes the PID file, and maintains compatibility with existing behavior.